### PR TITLE
Change max-pool-size to pool.max-size in examples

### DIFF
--- a/jpa/README.md
+++ b/jpa/README.md
@@ -329,7 +329,8 @@ kumuluzee:
       connection-url: jdbc:postgresql://localhost:5432/customers
       username: postgres
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20
 ```
 
 ### Build the microservice and run it

--- a/jpa/src/main/resources/config.yaml
+++ b/jpa/src/main/resources/config.yaml
@@ -4,4 +4,5 @@ kumuluzee:
       connection-url: jdbc:postgresql://localhost:5432/customers
       username: postgres
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20

--- a/kumuluzee-blog-samples/kumuluzee-kubernetes/customers/customers-api/src/main/resources/config.yaml
+++ b/kumuluzee-blog-samples/kumuluzee-kubernetes/customers/customers-api/src/main/resources/config.yaml
@@ -12,7 +12,8 @@ kumuluzee:
       connection-url: jdbc:postgresql://192.168.99.100:5432/customer
       username: dbuser
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20
   config:
     etcd:
       hosts: http://192.168.99.100:2379

--- a/kumuluzee-blog-samples/kumuluzee-kubernetes/orders/orders-api/src/main/resources/config.yaml
+++ b/kumuluzee-blog-samples/kumuluzee-kubernetes/orders/orders-api/src/main/resources/config.yaml
@@ -12,7 +12,8 @@ kumuluzee:
       connection-url: jdbc:postgresql://postgres-orders:5432/order
       username: dbuser
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20
   discovery:
     etcd:
       hosts: http://192.168.99.100:2379

--- a/kumuluzee-graphql-advanced/src/main/resources/config.yaml
+++ b/kumuluzee-graphql-advanced/src/main/resources/config.yaml
@@ -13,4 +13,5 @@ kumuluzee:
       connection-url: jdbc:postgresql://localhost:5432/faculty
       username: postgres
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20

--- a/kumuluzee-graphql-jpa-simple/src/main/resources/config.yaml
+++ b/kumuluzee-graphql-jpa-simple/src/main/resources/config.yaml
@@ -4,4 +4,5 @@ kumuluzee:
       connection-url: jdbc:postgresql://localhost:5432/customers
       username: postgres
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20

--- a/kumuluzee-health/README.md
+++ b/kumuluzee-health/README.md
@@ -166,7 +166,8 @@ kumuluzee:
       connection-url: jdbc:postgresql://localhost:5432/customers
       username: postgres
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20
   health:
     servlet:
       mapping: /health

--- a/kumuluzee-health/src/main/resources/config.yaml
+++ b/kumuluzee-health/src/main/resources/config.yaml
@@ -4,7 +4,8 @@ kumuluzee:
       connection-url: jdbc:postgresql://localhost:5432/customers
       username: postgres
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20
   health:
     servlet:
       mapping: /health

--- a/kumuluzee-rest/src/main/resources/config.yaml
+++ b/kumuluzee-rest/src/main/resources/config.yaml
@@ -4,4 +4,5 @@ kumuluzee:
       connection-url: jdbc:postgresql://localhost:5432/customers
       username: postgres
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20

--- a/microservices-simple/catalogue/src/main/resources/config.yaml
+++ b/microservices-simple/catalogue/src/main/resources/config.yaml
@@ -4,4 +4,5 @@ kumuluzee:
       connection-url: jdbc:postgresql://localhost:5432/postgres
       username: postgres
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20

--- a/microservices-simple/orders/src/main/resources/config.yaml
+++ b/microservices-simple/orders/src/main/resources/config.yaml
@@ -4,4 +4,5 @@ kumuluzee:
       connection-url: jdbc:postgresql://localhost:5432/postgres
       username: postgres
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20

--- a/tutorial-microservice-config-discovery-faulttolerance-logs-metrics-security/README.md
+++ b/tutorial-microservice-config-discovery-faulttolerance-logs-metrics-security/README.md
@@ -232,7 +232,8 @@ kumuluzee:
       connection-url: jdbc:postgresql://localhost:5432/customer
       username: postgres
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20
 ```
 
 ##### Define persistance.xml

--- a/tutorial-microservice-config-discovery-faulttolerance-logs-metrics-security/customers/customers-api/src/main/resources/config.yaml
+++ b/tutorial-microservice-config-discovery-faulttolerance-logs-metrics-security/customers/customers-api/src/main/resources/config.yaml
@@ -12,7 +12,8 @@ kumuluzee:
       connection-url: jdbc:postgresql://192.168.99.100:5432/customer
       username: postgres
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20
   config:
     etcd:
       hosts: http://192.168.99.100:2379

--- a/tutorial-microservice-config-discovery-faulttolerance-logs-metrics-security/orders/orders-api/src/main/resources/config.yaml
+++ b/tutorial-microservice-config-discovery-faulttolerance-logs-metrics-security/orders/orders-api/src/main/resources/config.yaml
@@ -12,7 +12,8 @@ kumuluzee:
       connection-url: jdbc:postgresql://192.168.99.100:5433/order
       username: postgres
       password: postgres
-      max-pool-size: 20
+      pool:
+        max-size: 20
   discovery:
     etcd:
       hosts: http://192.168.99.100:2379


### PR DESCRIPTION
Changes `max-pool-size` to
```
pool:
  max-size:
```
since `max-pool-size` does not seem to be a valid property according to [EeConfig wiki page](https://github.com/kumuluz/kumuluzee/wiki/EeConfig) and also does not work when used in a project.