### PR TITLE
Remove unused dependencies

### DIFF
--- a/kumuluzee-blog-samples/kumuluzee-kubernetes/orders/orders-persistence/pom.xml
+++ b/kumuluzee-blog-samples/kumuluzee-kubernetes/orders/orders-persistence/pom.xml
@@ -15,15 +15,24 @@
         <dependency>
             <groupId>com.kumuluz.ee</groupId>
             <artifactId>kumuluzee-jpa-eclipselink</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.kumuluz.ee.rest</groupId>
-            <artifactId>kumuluzee-rest-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.kumuluz.ee</groupId>
+                    <artifactId>kumuluzee-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>org.eclipse.persistence.asm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>org.eclipse.persistence.jpa.jpql</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>org.eclipse.persistence.antlr</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
@urbim Hi, I am a user of project **_com.kumuluz.ee.samples.blog:orders-persistence:1.0.0-SNAPSHOT_**. I found that its pom file introduced **_18_** dependencies. However, among them, **_12_** libraries (**_66%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_com.kumuluz.ee.samples.blog:orders-persistence:1.0.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.eclipse.persistence:org.eclipse.persistence.antlr:jar:2.6.5:compile
javax.annotation:javax.annotation-api:jar:1.3.2:compile
com.kumuluz.ee.rest:kumuluzee-rest-core:jar:1.1.0:compile
javax.servlet:javax.servlet-api:jar:3.1.0:compile
org.eclipse.persistence:org.eclipse.persistence.asm:jar:2.6.5:compile
org.postgresql:postgresql:jar:42.1.4:compile
com.kumuluz.ee:kumuluzee-common:jar:2.6.0:compile
org.slf4j:slf4j-api:jar:1.7.25:compile
com.zaxxer:HikariCP:jar:2.6.3:compile
javax.transaction:javax.transaction-api:jar:1.2:compile
org.yaml:snakeyaml:jar:1.18:compile
org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:jar:2.6.5:compile
</code></pre>