### PR TITLE
Could com.kumuluz.ee.samples.blog:orders-persistence:1.0.0-SNAPSHOT drop off redundant dependencies? 

### DIFF
--- a/kumuluzee-blog-samples/kumuluzee-kubernetes/orders/orders-persistence/pom.xml
+++ b/kumuluzee-blog-samples/kumuluzee-kubernetes/orders/orders-persistence/pom.xml
@@ -15,15 +15,24 @@
         <dependency>
             <groupId>com.kumuluz.ee</groupId>
             <artifactId>kumuluzee-jpa-eclipselink</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.kumuluz.ee.rest</groupId>
-            <artifactId>kumuluzee-rest-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.kumuluz.ee</groupId>
+                    <artifactId>kumuluzee-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>org.eclipse.persistence.asm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>org.eclipse.persistence.antlr</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>org.eclipse.persistence.jpa.jpql</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Hi! I found the pom file of project **_com.kumuluz.ee.samples.blog:orders-persistence:1.0.0-SNAPSHOT_** introduced **_18_** dependencies. However, among them, **_12_** libraries (**_66%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.eclipse.persistence:org.eclipse.persistence.antlr:jar:2.6.5:compile
javax.annotation:javax.annotation-api:jar:1.3.2:compile
com.kumuluz.ee.rest:kumuluzee-rest-core:jar:1.1.0:compile
javax.servlet:javax.servlet-api:jar:3.1.0:compile
org.eclipse.persistence:org.eclipse.persistence.asm:jar:2.6.5:compile
org.postgresql:postgresql:jar:42.1.4:compile
com.kumuluz.ee:kumuluzee-common:jar:2.6.0:compile
org.slf4j:slf4j-api:jar:1.7.25:compile
com.zaxxer:HikariCP:jar:2.6.3:compile
javax.transaction:javax.transaction-api:jar:1.2:compile
org.yaml:snakeyaml:jar:1.18:compile
org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:jar:2.6.5:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_org.postgresql:postgresql:jar:42.1.4:compile_** incorporates a high-level vulnerability SNYK-JAVA-ORGPOSTGRESQL-571481. As such, I suggest a refactoring operation for **_com.kumuluz.ee.samples.blog:orders-persistence:1.0.0-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.kumuluz.ee.samples.blog:orders-persistence:1.0.0-SNAPSHOT_**’s maven tests.

Best regards
![image](https://user-images.githubusercontent.com/78527112/162950885-73ca4ae4-45df-4522-850a-ea805780fcc5.png)
